### PR TITLE
Store body of requests

### DIFF
--- a/web-server-test.el
+++ b/web-server-test.el
@@ -184,6 +184,39 @@ org=-+one%0A-+two%0A-+three%0A-+four%0A%0A&beg=646&end=667&path=%2Fcomplex.org")
                              "org=-+one%0A-+two%0A-+three%0A-+four%0A%0A&beg=646&end=667&path=%2Fcomplex.org"))))
       (ws-stop server))))
 
+(ert-deftest ws/parse-json-data ()
+  "Ensure we can send arbitrary data through to the handler
+
+The handler can then parse it itself."
+  (let ((server (ws-start nil ws-test-port))
+        (request (make-instance 'ws-request)))
+    (unwind-protect
+        (progn
+          (setf (pending request)
+                "POST /complex.org HTTP/1.1
+Host: localhost:4444
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:26.0) Gecko/20100101 Firefox/26.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate
+DNT: 1
+Content-Type: application/json
+Referer: http://localhost:4444/complex.org
+Content-Length: 33
+Cookie: __utma=111872281.1462392269.1345929539.1345929539.1345929539.1
+Connection: keep-alive
+Pragma: no-cache
+Cache-Control: no-cache
+
+{\"some example\": \"json data\"}")
+          (ws-parse-request request)
+          (let ((headers (cdr (headers request))))
+            (should (string= (cdr (assoc :CONTENT-TYPE headers))
+                             "application/json"))
+            (should (string= (oref request body)
+                             "{\"some example\": \"json data\"}")))
+      (ws-stop server)))))
+
 (ert-deftest ws/simple-post ()
   "Test a simple POST server."
   (ws-test-with

--- a/web-server-test.el
+++ b/web-server-test.el
@@ -177,7 +177,11 @@ org=-+one%0A-+two%0A-+three%0A-+four%0A%0A&beg=646&end=667&path=%2Fcomplex.org")
 - three
 - four
 
-"))))
+"))
+            (should (string= (cdr (assoc :CONTENT-TYPE headers))
+                             "application/x-www-form-urlencoded; charset=UTF-8"))
+            (should (string= (oref request body)
+                             "org=-+one%0A-+two%0A-+three%0A-+four%0A%0A&beg=646&end=667&path=%2Fcomplex.org"))))
       (ws-stop server))))
 
 (ert-deftest ws/simple-post ()

--- a/web-server.el
+++ b/web-server.el
@@ -302,13 +302,13 @@ Return non-nil only when parsing is complete."
                   ;; will require special parsing.  Thus we will note
                   ;; the type in the CONTEXT variable for parsing
                   ;; dispatch above.
-                  (if (and (caar header) (eql (caar header) :CONTENT-TYPE))
-                      (cl-destructuring-bind (type &rest data)
-                          (mail-header-parse-content-type (cdar header))
-                        (setq boundary (cdr (assoc 'boundary data)))
-                        (setq context (intern (downcase type))))
-                    ;; All other headers are collected directly.
-                    (setcdr (last headers) header)))))
+                  (when (and (caar header) (eql (caar header) :CONTENT-TYPE))
+                    (cl-destructuring-bind (type &rest data)
+                        (mail-header-parse-content-type (cdar header))
+                      (setq boundary (cdr (assoc 'boundary data)))
+                      (setq context (intern (downcase type)))))
+                  ;; All other headers are collected directly.
+                  (setcdr (last headers) header))))
             (setq index tmp)))))
     (setf (active request) nil)
     nil))

--- a/web-server.el
+++ b/web-server.el
@@ -4,7 +4,7 @@
 
 ;; Author: Eric Schulte <schulte.eric@gmail.com>
 ;; Maintainer: Eric Schulte <schulte.eric@gmail.com>
-;; Version: 0.1.1
+;; Version: 0.1.2
 ;; Package-Requires: ((emacs "24.3"))
 ;; Keywords: http, server, network
 ;; URL: https://github.com/eschulte/emacs-web-server


### PR DESCRIPTION
Closes #11 

This PR adds a new slot for the body of a request. When parsing the request, everything after the first double CRLF is considered `body`. This allows the server-side user to parse arbitrary content types in their own handler. Also stores the `Content-type` in the headers - it was being discarded before. This is necessary so the user can determine how to decode incoming content.

An obvious use case is a user who wishes to post JSON to their Emacs server.

I'm successfully [powering](https://github.com/jcaw/porthole/tree/web-server-backend-2) another project, [Porthole](https://www.github.com/jcaw/porthole), using these changes. It currently runs on Elnode. The `web-server` implementation is a lot nicer, I'd like to switch if these changes are merged upstream.

Tests are included - one new, plus a modification to the existing basic POST test. All tests pass on Linux.