### PR TITLE
Remove obsolete function

### DIFF
--- a/web-server.el
+++ b/web-server.el
@@ -118,7 +118,7 @@ function.
 "
   (let ((server (make-instance 'ws-server :handlers handlers :port port))
         (log (when log-buffer (get-buffer-create log-buffer))))
-    (setf (process server)
+    (setf (ws-process server)
           (apply
            #'make-network-process
            :name "ws-server"


### PR DESCRIPTION
I noticed the issue with byte compiler

In end of data:
web-server.el:750:1:Warning: the function ‘(setf process)’ is not known to be
    defined.