### PR TITLE
Fix ws-start docstring

### DIFF
--- a/web-server.el
+++ b/web-server.el
@@ -381,9 +381,9 @@ in the request handler.  If no web-socket connection is
 established (e.g., because REQUEST is not attempting to establish
 a connection) then no actions are taken and nil is returned.
 
-Second argument HANDLER should be a function of one argument
-which will be called on all complete messages as they are
-received and parsed from the network."
+Second argument HANDLER should be a function of two arguments,
+the process and a string, which will be called on all complete
+messages as they are received and parsed from the network."
   (with-slots (process headers) request
     (when (assoc :SEC-WEBSOCKET-KEY headers)
       ;; Accept the connection

--- a/web-server.el
+++ b/web-server.el
@@ -108,11 +108,11 @@ function MATCH and the `ws-response-header' convenience
 function.
 
   (ws-start
-   '(((lambda (_) t) .
-      (lambda (proc request)
-        (ws-response-header proc 200 '(\"Content-type\" . \"text/plain\"))
-        (process-send-string proc \"hello world\")
-        t)))
+   (list (cons (lambda (_request) t)
+               (lambda (request)
+                 (with-slots ((proc process)) request
+                   (ws-response-header proc 200 '(\"Content-Type\" . \"text/plain\"))
+                   (process-send-string proc \"hello world\")))))
    8080)
 
 "


### PR DESCRIPTION
The handler function takes (REQUEST) instead of (PROC REQUEST).

The old example code in the docstring does not work:

```
(ws-start
 '(((lambda (_) t) .
    (lambda (proc request)
      (ws-response-header proc 200 '("Content-type" . "text/plain"))
      (process-send-string proc "hello world")
      t)))
 8080)

~ $ curl localhost:8080
Caught Error: (wrong-number-of-arguments (lambda (proc request) (ws-response-header proc 200 '("Content-type" . "text/plain")) (process-send-string proc "hello world") t) 1)
```