### PR TITLE
drop Emacs dependency to 24.1 and depends ELPA's cl-lib

### DIFF
--- a/web-server.el
+++ b/web-server.el
@@ -5,7 +5,7 @@
 ;; Author: Eric Schulte <schulte.eric@gmail.com>
 ;; Maintainer: Eric Schulte <schulte.eric@gmail.com>
 ;; Version: 0.1.2
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.1") (cl-lib "0.6"))
 ;; Keywords: http, server, network
 ;; URL: https://github.com/eschulte/emacs-web-server
 


### PR DESCRIPTION
Drop Emacs dependency to 24.1 and depends ELPA's cl-lib (this PR fixes eschulte#21)