### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/web-server.el
+++ b/web-server.el
@@ -4,7 +4,7 @@
 
 ;; Author: Eric Schulte <schulte.eric@gmail.com>
 ;; Maintainer: Eric Schulte <schulte.eric@gmail.com>
-;; Version: 0.1.2
+;; Version: 0.1.3
 ;; Package-Requires: ((emacs "24.1") (cl-lib "0.6"))
 ;; Keywords: http, server, network
 ;; URL: https://github.com/eschulte/emacs-web-server


### PR DESCRIPTION
Please consider bumping the version to release the latest fixes, among them fixes for these byte-compiler warnings in Emacs 29:

```
In toplevel form:
web-server.el: Warning: ‘case’ is an obsolete alias (as of 27.1); use ‘cl-case’ instead.
web-server.el: Warning: ‘incf’ is an obsolete alias (as of 27.1); use ‘cl-incf’ instead.
web-server.el: Warning: ‘incf’ is an obsolete alias (as of 27.1); use ‘cl-incf’ instead.
web-server.el: Warning: ‘case’ is an obsolete alias (as of 27.1); use ‘cl-case’ instead.
web-server.el: Warning: ‘incf’ is an obsolete alias (as of 27.1); use ‘cl-incf’ instead.
web-server.el: Warning: ‘ecase’ is an obsolete alias (as of 27.1); use ‘cl-ecase’ instead.
web-server.el: Warning: ‘ecase’ is an obsolete alias (as of 27.1); use ‘cl-ecase’ instead.
web-server.el: Warning: ‘ecase’ is an obsolete alias (as of 27.1); use ‘cl-ecase’ instead.
```